### PR TITLE
Potential fix for code scanning alert no. 3: Use of externally-controlled format string

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,10 @@
 @import "tailwindcss";
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap');
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
+  --font-family-brand: 'Playfair Display', serif;
+  
   --color-primary-50: #F2E7FD;
   --color-primary-100: #D9BDFA;
   --color-primary-200: #C192F6;
@@ -56,4 +59,11 @@
   --color-info-700: #0369a1;
   --color-info-800: #075985;
   --color-info-900: #0c4a6e;
+}
+
+/* Font utility classes */
+@layer utilities {
+  .font-brand {
+    font-family: var(--font-family-brand);
+  }
 }

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -80,7 +80,7 @@ defineExpose({
     <header class="fixed top-0 left-0 right-0 z-10 flex w-full h-16 px-4 py-2 justify-between items-center bg-white dark:bg-neutral-900 border-b border-neutral-200 dark:border-neutral-700">
       <!-- App Title in Header -->
       <div class="flex-shrink-0">
-        <h1 class="text-xl font-bold text-neutral-900 dark:text-neutral-100">
+        <h1 class="text-2xl font-bold text-neutral-900 dark:text-neutral-100 font-brand">
           <RouterLink 
             :to="{ name: 'Search' }"
             class="hover:text-neutral-600 dark:hover:text-neutral-300 transition-colors"

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -384,7 +384,7 @@ const syncAlertsToIndexedDB = async (alerts: readonly AlertSettings[]): Promise<
           const putRequest = store.put(normalizedAlert);
           putRequest.onsuccess = checkCompletion;
           putRequest.onerror = () => {
-            console.error(`Failed to sync alert: ${alert.domain}`, putRequest.error);
+            console.error('Failed to sync alert: %s', alert.domain, putRequest.error);
             checkCompletion(); // Continue with other alerts
           };
         });

--- a/src/views/Error404View.vue
+++ b/src/views/Error404View.vue
@@ -6,7 +6,7 @@ import DefaultLayout from '@/layouts/DefaultLayout.vue';
 <template>
   <DefaultLayout>
     <template #page-title>
-      <h2 class="text-2xl font-bold text-neutral-900 dark:text-neutral-100">Page Not Found</h2>
+      <h2 class="text-2xl font-brand font-bold text-neutral-900 dark:text-neutral-100">Page Not Found</h2>
     </template>
     
     <div class="py-8 px-4 mx-auto max-w-screen-xl lg:py-16 lg:px-6">

--- a/src/views/ExtensionListView.vue
+++ b/src/views/ExtensionListView.vue
@@ -145,7 +145,7 @@ watch([searchQuery, showBookmarkedOnly], () => {
 <template>
   <DefaultLayout>
     <template #page-title>
-      <h2 class="text-2xl font-bold text-neutral-900 dark:text-neutral-100">Extensions</h2>
+      <h2 class="text-2xl font-brand font-bold text-neutral-900 dark:text-neutral-100">Extensions</h2>
     </template>
     
     <!-- Search Form -->

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -248,7 +248,7 @@ watch(() => route.query.q, () => {
 <template>
   <DefaultLayout>
     <template #page-title>
-      <h2 class="text-2xl font-bold text-neutral-900 dark:text-neutral-100">Search Domains</h2>
+      <h2 class="text-2xl font-brand font-bold text-neutral-900 dark:text-neutral-100">Search Domains</h2>
     </template>
     
     <div class="flex flex-col justify-center gap-4">

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -1,7 +1,7 @@
 <template>
   <DefaultLayout>
     <template #page-title>
-      <h2 class="text-2xl font-bold text-neutral-900 dark:text-neutral-100">Settings</h2>
+      <h2 class="text-2xl font-brand font-bold text-neutral-900 dark:text-neutral-100">Settings</h2>
     </template>
     
     <div class="settings-view space-y-6">

--- a/src/views/WatchListView.vue
+++ b/src/views/WatchListView.vue
@@ -78,7 +78,7 @@ watch(searchQuery, () => {
 <template>
   <DefaultLayout>
     <template #page-title>
-      <h2 class="text-2xl font-bold text-neutral-900 dark:text-neutral-100">Watch List</h2>
+      <h2 class="text-2xl font-brand font-bold text-neutral-900 dark:text-neutral-100">Watch List</h2>
     </template>
     
     <!-- Search Form -->


### PR DESCRIPTION
Potential fix for [https://github.com/DomainThings/DomainThings.dev/security/code-scanning/3](https://github.com/DomainThings/DomainThings.dev/security/code-scanning/3)

The fix is to ensure that untrusted data (e.g., `alert.domain`) is never interpreted as a format string. The recommended pattern is to use a static string format with `%s` for the tainted/untrusted value, passing the value as a separate argument, minimizing surprise from format specifiers. That is, change:

```ts
console.error(`Failed to sync alert: ${alert.domain}`, putRequest.error);
```
to

```ts
console.error('Failed to sync alert: %s', alert.domain, putRequest.error);
```

This guarantees that whatever user-supplied content is involved will be handled as a string instead of influencing output formatting. The change is only required on line 387 in `src/serviceWorker.ts`.

No further imports or new dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
