### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ on:
   schedule:
     - cron: '0 8 * * *'  # Every day at 8 AM UTC
 
+permissions:
+  contents: read
+
 jobs:
   # Build and type check - REQUIRED for PR protection
   build-and-type-check:


### PR DESCRIPTION
Potential fix for [https://github.com/DomainThings/DomainThings.dev/security/code-scanning/2](https://github.com/DomainThings/DomainThings.dev/security/code-scanning/2)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token access.  
For this workflow, `contents: read` is sufficient (needed by `actions/checkout`; no write actions are present).

Best single fix (minimal and safe):
- Edit `.github/workflows/ci.yml`
- Insert after the `on:` triggers block and before `jobs:`
  ```yaml
  permissions:
    contents: read
  ```
No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
